### PR TITLE
build: Make eat use the latest zip in $OUT

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -80,9 +80,7 @@ alias bib=breakfast
 function eat()
 {
     if [ "$OUT" ] ; then
-        MODVERSION=$(get_build_var LINEAGE_VERSION)
-        ZIPFILE=lineage-$MODVERSION.zip
-        ZIPPATH=$OUT/$ZIPFILE
+        ZIPPATH=`ls -tr "$OUT"/lineage-*.zip | tail -1`
         if [ ! -f $ZIPPATH ] ; then
             echo "Nothing to eat"
             return 1


### PR DESCRIPTION
* Fixes weird issues with timestamp differences

Change-Id: Ibeb0c5043b646faab6ce372290acf7efb4f22e15